### PR TITLE
Add manual trigger to .NET GitHub Actions workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,6 +4,7 @@
 name: .NET
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "master" ]
   pull_request:


### PR DESCRIPTION
Enabled the `workflow_dispatch` event to allow manually triggering the workflow. This provides flexibility in running the workflow outside the usual push or pull request events.