### PR TITLE
chore: upgrade CycloneDX.Core to 11.0.0 (spec 1.7)

### DIFF
--- a/src/CdxEnrich/CdxEnrich.csproj
+++ b/src/CdxEnrich/CdxEnrich.csproj
@@ -35,7 +35,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CycloneDX.Core" Version="8.0.3" />
+		<PackageReference Include="CycloneDX.Core" Version="11.0.0" />
 		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- CycloneDX.Core: 8.0.3 → 11.0.0
- Adds support for CycloneDX specification 1.7
- All 66 tests passing