### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/mtsfoni/cdx-enrich/security/code-scanning/2](https://github.com/mtsfoni/cdx-enrich/security/code-scanning/2)

In general, the fix is to explicitly declare the minimal required `GITHUB_TOKEN` permissions at the workflow or job level using a `permissions:` block. For this workflow, the steps only read code and restore/build/test dependencies; they do not write to the repository, PRs, or issues. Therefore, the least-privilege setting is `contents: read`.

The best fix without changing existing functionality is to add a root-level `permissions:` block just under the `name:` and before `on:` in `.github/workflows/dotnet.yml`. This will apply to all jobs (currently just `build`) and override any broader default repo/org settings. No imports or additional methods are needed, as this is pure workflow configuration.

Concretely, edit `.github/workflows/dotnet.yml` to insert:

```yml
permissions:
  contents: read
```

between lines 5 and 6 of the provided snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
