### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:


### PR DESCRIPTION
Potential fix for [https://github.com/mtsfoni/cdx-enrich/security/code-scanning/1](https://github.com/mtsfoni/cdx-enrich/security/code-scanning/1)

In general, fix this by adding a `permissions` block that explicitly lists only the scopes the job needs. This can be done at the workflow root (applies to all jobs) or within the specific job. Here, only the `build` job exists, and it needs to create a release and upload assets, which require `contents: write`. It does not appear to need other elevated scopes like `issues`, `pull-requests`, or `packages`.

The best minimal fix without changing functionality is to add a `permissions` block to the `build` job (or at the root). Since the warning is on the job, we’ll attach it there. Place:

```yaml
permissions:
  contents: write
```

under `jobs: build:` and aligned correctly with other job-level keys (`runs-on`, `timeout-minutes`). No additional imports or code changes are necessary; this only influences the `GITHUB_TOKEN` permission set used by `actions/create-release` and `actions/upload-release-asset`.

Specifically, modify `.github/workflows/release.yml` around lines 9–15 to insert the `permissions` key between `build:` and `runs-on:`. No other lines in the file need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
